### PR TITLE
Use hyprpm to manage hyprbars plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,10 +26,16 @@ A rice inspired by `NieR:Automata` ui
     - ### Dependancies
         #### Arch
         > ```sh
-        > paru -S hyprland-git foot grim swww-git fish theme.sh aylurs-gtk-shell-git sassc starship cava imagemagick hyprland-plugin-hyprbars-git gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 nerd-fonts
+        > paru -S hyprland-git foot grim swww-git fish theme.sh aylurs-gtk-shell-git sassc starship cava imagemagick gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 nerd-fonts cpio cmake git meson gcc
         > ```
         #### STTT
         > install from https://github.com/flick0/sttt
+    - ### Install and enable `hyprbars` plugin via `hyprpm`
+      > ```sh
+      > hyprpm update
+      > hyprpm add https://github.com/hyprwm/hyprland-plugins
+      > hyprpm enable hyprbars
+      > ```
     - ### Clone to theme folder
       ```sh
       mkdir ~/.config/hypr/themes && git clone -b hyprland-yorha https://github.com/flick0/dotfiles ~/.config/hypr/themes/yorha

--- a/theme.conf
+++ b/theme.conf
@@ -5,7 +5,7 @@ exec-once=pkill ags
 exec=sleep 1 && ags -c $yorha/components/ags/config.js
 exec=swww-daemon
 exec=sleep 1 && swww img $yorha/wallpapers/nier_light.png --transition-type simple --transition-step 255
-exec=sleep 1 && hyprctl plugin load /lib/hyprland-plugins/hyprbars.so
+exec-once=hyprpm reload -n
 
 bind=Super,o,exec,$DRUN
 


### PR DESCRIPTION
`readme.md`
- Ensure dependencies for `hyprpm` are installed
- Install/enable `hyprbars` using `hyprpm`

`theme.conf`
- Load `hyprbars` using`hyprpm`, as recommended by the [Hyprland Wiki](https://wiki.hypr.land/Plugins/Using-Plugins/)